### PR TITLE
Finish SeeMoreScreen & RecipeScreen connectionⓂ️

### DIFF
--- a/lib/core/di/dependency_injection.dart
+++ b/lib/core/di/dependency_injection.dart
@@ -4,6 +4,8 @@ import 'package:food_recipes_app/core/networking/dio_factory.dart';
 import 'package:food_recipes_app/core/networking/food_api_services.dart';
 import 'package:food_recipes_app/features/home/data/repos/home_repo.dart';
 import 'package:food_recipes_app/features/home/logic/cubit/home_cubit.dart';
+import 'package:food_recipes_app/features/recipe/data/repos/recipe_repo.dart';
+import 'package:food_recipes_app/features/recipe/logic/cubit/recipe_cubit.dart';
 import 'package:food_recipes_app/features/see_more/data/repos/see_more_repo.dart';
 import 'package:food_recipes_app/features/see_more/logic/cubit/see_more_cubit.dart';
 import 'package:get_it/get_it.dart';
@@ -20,6 +22,7 @@ void setupGetIt() {
   // Cubits
   getIt.registerFactory<HomeCubit>(() => HomeCubit(getIt()));
   getIt.registerFactory<SeeMoreCubit>(() => SeeMoreCubit(getIt()));
+  getIt.registerFactory<RecipeCubit>(() => RecipeCubit(getIt()));
 
   // Repos
   getIt.registerLazySingleton<HomeRepo>(() => HomeRepo(
@@ -27,4 +30,5 @@ void setupGetIt() {
         getIt(),
       ));
   getIt.registerLazySingleton<SeeMoreRepo>(() => SeeMoreRepo(getIt(), getIt()));
+  getIt.registerLazySingleton<RecipeRepo>(() => RecipeRepo(getIt(), getIt()));
 }

--- a/lib/core/models/recipe_item_model.dart
+++ b/lib/core/models/recipe_item_model.dart
@@ -8,8 +8,9 @@ class RecipeItemModel {
   final List<String> measures;
   final String? subtitle;
   final String? tags;
-  final String? glass;
   final String? youTubeVideoUrl;
+  String? glass;
+  String? section;
 
   RecipeItemModel({
     required this.id,
@@ -19,6 +20,21 @@ class RecipeItemModel {
     required this.steps,
     required this.ingredients,
     required this.measures,
+    this.subtitle,
+    this.tags,
+    this.glass,
+    this.youTubeVideoUrl,
+  });
+
+  RecipeItemModel.fromId({
+    required this.id,
+    required this.section,
+    this.title = '',
+    this.imageUrl = '',
+    this.category = '',
+    this.steps = '',
+    this.ingredients = const [],
+    this.measures = const [],
     this.subtitle,
     this.tags,
     this.glass,

--- a/lib/core/networking/api_constant.dart
+++ b/lib/core/networking/api_constant.dart
@@ -6,4 +6,5 @@ class ApiConstant {
   static const String categories = 'categories.php';
   static const String list = 'list.php';
   static const String filter = 'filter.php';
+  static const String search = 'lookup.php';
 }

--- a/lib/core/networking/cocktail_api_services.dart
+++ b/lib/core/networking/cocktail_api_services.dart
@@ -23,4 +23,9 @@ abstract class CocktailApiServices {
   Future<CocktailFilterResponseModel> getFilteredData(
     @Query('c') String category,
   );
+
+  @GET(ApiConstant.search)
+  Future<CocktailResponseModel> getByID(
+    @Query('i') String id,
+  );
 }

--- a/lib/core/networking/cocktail_api_services.g.dart
+++ b/lib/core/networking/cocktail_api_services.g.dart
@@ -102,6 +102,33 @@ class _CocktailApiServices implements CocktailApiServices {
     return _value;
   }
 
+  @override
+  Future<CocktailResponseModel> getByID(String id) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'i': id};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<CocktailResponseModel>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              'lookup.php',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+    final _value = CocktailResponseModel.fromJson(_result.data!);
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/core/networking/food_api_services.dart
+++ b/lib/core/networking/food_api_services.dart
@@ -21,4 +21,9 @@ abstract class FoodApiServices {
   Future<FoodFilterResponseModel> getFilteredData(
     @Query('c') String category,
   );
+
+  @GET(ApiConstant.search)
+  Future<FoodResponseModel> getByID(
+    @Query('i') String id,
+  );
 }

--- a/lib/core/networking/food_api_services.g.dart
+++ b/lib/core/networking/food_api_services.g.dart
@@ -101,6 +101,33 @@ class _FoodApiServices implements FoodApiServices {
     return _value;
   }
 
+  @override
+  Future<FoodResponseModel> getByID(String id) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'i': id};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _result = await _dio
+        .fetch<Map<String, dynamic>>(_setStreamType<FoodResponseModel>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              'lookup.php',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+    final _value = FoodResponseModel.fromJson(_result.data!);
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:food_recipes_app/core/models/recipe_item_model.dart';
 import 'package:food_recipes_app/features/Auth/ui/auth_screen.dart';
 import 'package:food_recipes_app/features/initial/ui/get_started_screen.dart';
+import 'package:food_recipes_app/features/recipe/logic/cubit/recipe_cubit.dart';
 import 'package:food_recipes_app/features/recipe/ui/recipe_screen.dart';
 import 'package:food_recipes_app/features/settings/preferances_screen.dart';
 import 'package:flutter/material.dart';
@@ -42,8 +43,11 @@ class AppRouter {
         );
       case AppRoutes.recipeDetails:
         return MaterialPageRoute(
-          builder: (_) => RecipeScreen(
-            recipe: args as RecipeItemModel,
+          builder: (_) => BlocProvider<RecipeCubit>(
+            create: (context) => getIt<RecipeCubit>(),
+            child: RecipeScreen(
+              recipe: args as RecipeItemModel,
+            ),
           ),
         );
       case AppRoutes.seeMore:

--- a/lib/features/recipe/data/repos/recipe_repo.dart
+++ b/lib/features/recipe/data/repos/recipe_repo.dart
@@ -1,0 +1,24 @@
+import 'package:food_recipes_app/core/models/cocktail_response_model.dart';
+import 'package:food_recipes_app/core/models/food_response_model.dart';
+import 'package:food_recipes_app/core/networking/cocktail_api_services.dart';
+import 'package:food_recipes_app/core/networking/food_api_services.dart';
+
+class RecipeRepo {
+  final FoodApiServices _foodApiServices;
+  final CocktailApiServices _cocktailApiServices;
+
+  RecipeRepo(this._foodApiServices, this._cocktailApiServices);
+
+  // Food
+  Future<MealModel> getFoodDataById(String id) async {
+    final FoodResponseModel foodRecipeData = await _foodApiServices.getByID(id);
+    return foodRecipeData.meals.first;
+  }
+
+  // Cocktail
+  Future<CocktailModel> getCocktailDataById(String id) async {
+    final CocktailResponseModel cocktailRecipeData =
+        await _cocktailApiServices.getByID(id);
+    return cocktailRecipeData.cocktails.first;
+  }
+}

--- a/lib/features/recipe/logic/cubit/recipe_cubit.dart
+++ b/lib/features/recipe/logic/cubit/recipe_cubit.dart
@@ -1,0 +1,69 @@
+import 'package:bloc/bloc.dart';
+import 'package:food_recipes_app/core/models/cocktail_response_model.dart';
+import 'package:food_recipes_app/core/models/food_response_model.dart';
+import 'package:food_recipes_app/core/models/recipe_item_model.dart';
+import 'package:food_recipes_app/features/recipe/data/repos/recipe_repo.dart';
+import 'package:food_recipes_app/features/recipe/logic/cubit/recipe_state.dart';
+
+class RecipeCubit extends Cubit<RecipeState> {
+  RecipeCubit(this._recipeRepo) : super(RecipeInitial());
+
+  final RecipeRepo _recipeRepo;
+
+  void setupScreenData(RecipeItemModel recipe) async {
+    // If the received recipe data not completed (From SeeMore screen)
+    if (recipe.section != null) {
+      emit(RecipeLoading());
+
+      final RecipeItemModel recipeData = await getRecipeDataById(recipe);
+      emit(RecipeSuccess(recipeData));
+
+      // emit(RecipeError(e.toString()));
+
+      // If the received recipe data is completed (From Home screen)
+    } else {
+      emit(RecipeSuccess(recipe));
+    }
+  }
+
+  Future<RecipeItemModel> _getFoodDataById(String id) async {
+    final MealModel meal = await _recipeRepo.getFoodDataById(id);
+    return RecipeItemModel(
+      id: meal.id,
+      title: meal.name,
+      imageUrl: meal.imageUrl,
+      category: meal.category,
+      steps: meal.steps,
+      ingredients: meal.ingredientsList,
+      measures: meal.measuresList,
+      subtitle: meal.country,
+      tags: meal.tags,
+      youTubeVideoUrl: meal.youTubeVideoUrl,
+    );
+  }
+
+  Future<RecipeItemModel> _getCocktailDataById(String id) async {
+    final CocktailModel cocktail = await _recipeRepo.getCocktailDataById(id);
+    return RecipeItemModel(
+      id: cocktail.id,
+      title: cocktail.name,
+      imageUrl: cocktail.imageUrl,
+      category: cocktail.category,
+      steps: cocktail.steps,
+      ingredients: cocktail.ingredientsList,
+      measures: cocktail.measuresList,
+      subtitle: cocktail.alcoholic,
+      tags: cocktail.tags,
+      youTubeVideoUrl: cocktail.youTubeVideoUrl,
+      glass: cocktail.glass,
+    );
+  }
+
+  Future<RecipeItemModel> getRecipeDataById(RecipeItemModel recipe) async {
+    if (recipe.section == 'food') {
+      return await _getFoodDataById(recipe.id);
+    } else {
+      return await _getCocktailDataById(recipe.id);
+    }
+  }
+}

--- a/lib/features/recipe/logic/cubit/recipe_state.dart
+++ b/lib/features/recipe/logic/cubit/recipe_state.dart
@@ -1,0 +1,19 @@
+import 'package:food_recipes_app/core/models/recipe_item_model.dart';
+
+abstract class RecipeState {}
+
+final class RecipeInitial extends RecipeState {}
+
+final class RecipeLoading extends RecipeState {}
+
+final class RecipeSuccess extends RecipeState {
+  RecipeSuccess(this.recipe);
+
+  final RecipeItemModel recipe;
+}
+
+final class RecipeError extends RecipeState {
+  RecipeError(this.message);
+
+  final String message;
+}

--- a/lib/features/recipe/ui/recipe_screen.dart
+++ b/lib/features/recipe/ui/recipe_screen.dart
@@ -1,16 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:food_recipes_app/core/helpers/spacing.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:food_recipes_app/core/models/recipe_item_model.dart';
-import 'package:food_recipes_app/core/theming/app_colors.dart';
-import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_category_container.dart';
-import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_how_to_prepare.dart';
-import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_ingredients_list.dart';
-import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_screen_header.dart';
-import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_image.dart';
-import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_screen_section_header.dart';
-import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_title_and_subtitle.dart';
-import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_youtube_video_button.dart';
+import 'package:food_recipes_app/features/recipe/logic/cubit/recipe_cubit.dart';
+import 'package:food_recipes_app/features/recipe/logic/cubit/recipe_state.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_screen_shimmer.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_screen_body.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_screen_error.dart';
 
 class RecipeScreen extends StatelessWidget {
   const RecipeScreen({super.key, required this.recipe});
@@ -19,45 +14,46 @@ class RecipeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.lightestGrey,
-      body: Padding(
-        padding: EdgeInsets.only(top: 60.h),
-        child: CustomScrollView(
-          slivers: [
-            const RecipeScreenHeader(),
-            verticalSliverSpace(25),
-            RecipeImage(
-              imageUrl: recipe.imageUrl,
-            ),
-            verticalSliverSpace(45),
-            RecipeCategoryContainer(
-              categoryName: recipe.category,
-            ),
-            verticalSliverSpace(35),
-            RecipeTitleAndSubtitle(
-              title: recipe.title,
-              subtitle: recipe.subtitle!,
-            ),
-            verticalSliverSpace(40),
-            const RecipeScreenSectionHeader(title: 'Ingredients'),
-            RecipeIngredientsList(
-              ingredients: recipe.ingredients,
-              amounts: recipe.measures,
-            ),
-            verticalSliverSpace(40),
-            const RecipeScreenSectionHeader(title: 'How to prepare'),
-            RecipeHowToPrepare(
-              description: recipe.steps,
-            ),
-            verticalSliverSpace(30),
-            if (recipe.youTubeVideoUrl != null)
-              RecipeYoutubeVideoButton(
-                videoUrl: recipe.youTubeVideoUrl!,
-              ),
-          ],
-        ),
-      ),
+    // Setup screen data
+    context.read<RecipeCubit>().setupScreenData(recipe);
+    return BlocBuilder<RecipeCubit, RecipeState>(
+        buildWhen: (previous, current) =>
+            current is RecipeLoading ||
+            current is RecipeSuccess ||
+            current is RecipeError,
+        builder: (context, state) {
+          switch (state) {
+            case RecipeLoading():
+              {
+                return _setupLoading();
+              }
+            case RecipeSuccess():
+              {
+                return _setupSuccess(state.recipe);
+              }
+            case RecipeError():
+              {
+                return _setupError();
+              }
+            default:
+              {
+                return _setupLoading();
+              }
+          }
+        });
+  }
+
+  Widget _setupSuccess(RecipeItemModel tragetedRecipe) {
+    return RecipeScreenBody(
+      recipe: tragetedRecipe,
     );
+  }
+
+  Widget _setupLoading() {
+    return const RecipeScreenShimmer();
+  }
+
+  Widget _setupError() {
+    return const RecipeScreenError();
   }
 }

--- a/lib/features/recipe/ui/widgets/recipe_ingredients_item.dart
+++ b/lib/features/recipe/ui/widgets/recipe_ingredients_item.dart
@@ -30,10 +30,14 @@ class RecipeIngredientsItem extends StatelessWidget {
           style: AppTextStyles.font17DarkestGreyRegular,
         ),
         trailing: Text(
-          ingredientAmount,
+          _getIngredientAmount(),
           style: AppTextStyles.font17DarkestGreyRegular,
         ),
       ),
     );
+  }
+
+  String _getIngredientAmount() {
+    return ingredientAmount.split(' ').first;
   }
 }

--- a/lib/features/recipe/ui/widgets/recipe_screen_body.dart
+++ b/lib/features/recipe/ui/widgets/recipe_screen_body.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:food_recipes_app/core/helpers/spacing.dart';
+import 'package:food_recipes_app/core/models/recipe_item_model.dart';
+import 'package:food_recipes_app/core/theming/app_colors.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_image.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_category_container.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_how_to_prepare.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_ingredients_list.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_screen_header.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_screen_section_header.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_title_and_subtitle.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_youtube_video_button.dart';
+
+class RecipeScreenBody extends StatelessWidget {
+  const RecipeScreenBody({
+    super.key,
+    required this.recipe,
+  });
+
+  final RecipeItemModel recipe;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.lightestGrey,
+      body: Padding(
+        padding: EdgeInsets.only(top: 60.h),
+        child: CustomScrollView(
+          slivers: [
+            const SliverToBoxAdapter(
+              child: RecipeScreenHeader(),
+            ),
+            verticalSliverSpace(25),
+            RecipeImage(
+              imageUrl: recipe.imageUrl,
+            ),
+            verticalSliverSpace(45),
+            RecipeCategoryContainer(
+              categoryName: recipe.category,
+            ),
+            verticalSliverSpace(35),
+            RecipeTitleAndSubtitle(
+              title: recipe.title,
+              subtitle: recipe.subtitle ?? '',
+            ),
+            verticalSliverSpace(40),
+            const RecipeScreenSectionHeader(title: 'Ingredients'),
+            RecipeIngredientsList(
+              ingredients: recipe.ingredients,
+              amounts: recipe.measures,
+            ),
+            verticalSliverSpace(40),
+            const RecipeScreenSectionHeader(title: 'How to prepare'),
+            RecipeHowToPrepare(
+              description: recipe.steps,
+            ),
+            verticalSliverSpace(30),
+            if (recipe.youTubeVideoUrl != null)
+              RecipeYoutubeVideoButton(
+                videoUrl: recipe.youTubeVideoUrl!,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/recipe/ui/widgets/recipe_screen_error.dart
+++ b/lib/features/recipe/ui/widgets/recipe_screen_error.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:food_recipes_app/core/helpers/spacing.dart';
+import 'package:food_recipes_app/core/theming/app_colors.dart';
+import 'package:food_recipes_app/core/theming/app_text_styles.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_screen_header.dart';
+
+class RecipeScreenError extends StatelessWidget {
+  const RecipeScreenError({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.lightestGrey,
+      body: Padding(
+        padding: EdgeInsets.only(top: 60.h),
+        child: Column(
+          children: [
+            const RecipeScreenHeader(),
+            verticalSpace(25),
+            const Center(
+              child: Text(
+                'An error occurred while loading the recipe.',
+                style: AppTextStyles.font28BlackRegular,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/recipe/ui/widgets/recipe_screen_header.dart
+++ b/lib/features/recipe/ui/widgets/recipe_screen_header.dart
@@ -7,32 +7,30 @@ class RecipeScreenHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SliverToBoxAdapter(
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 20.w),
-        child: Row(
-          children: [
-            IconButton(
-              onPressed: () {
-                Navigator.pop(context);
-              },
-              icon: Icon(
-                Icons.keyboard_arrow_left_sharp,
-                size: 32.r,
-                color: AppColors.black,
-              ),
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 20.w),
+      child: Row(
+        children: [
+          IconButton(
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            icon: Icon(
+              Icons.keyboard_arrow_left_sharp,
+              size: 32.r,
+              color: AppColors.black,
             ),
-            const Spacer(),
-            IconButton(
-              onPressed: () {},
-              icon: Icon(
-                Icons.favorite_border,
-                size: 28.r,
-                color: AppColors.black,
-              ),
+          ),
+          const Spacer(),
+          IconButton(
+            onPressed: () {},
+            icon: Icon(
+              Icons.favorite_border,
+              size: 28.r,
+              color: AppColors.black,
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/recipe/ui/widgets/recipe_screen_shimmer.dart
+++ b/lib/features/recipe/ui/widgets/recipe_screen_shimmer.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:food_recipes_app/core/helpers/spacing.dart';
+import 'package:food_recipes_app/core/theming/app_colors.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/recipe_screen_header.dart';
+import 'package:food_recipes_app/features/recipe/ui/widgets/shimmer_item.dart';
+
+class RecipeScreenShimmer extends StatelessWidget {
+  const RecipeScreenShimmer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.lightestGrey,
+      body: Padding(
+        padding: EdgeInsets.only(top: 60.h, left: 20.w, right: 20.w),
+        child: Column(
+          children: [
+            const RecipeScreenHeader(),
+            verticalSpace(30),
+            const ShimmerItem(width: 200, height: 200, isCircular: true),
+            verticalSpace(50),
+            const ShimmerItem(
+                width: double.infinity, height: 35, isCircular: false),
+            verticalSpace(35),
+            const ShimmerItem(width: 200, height: 25, isCircular: false),
+            verticalSpace(10),
+            const ShimmerItem(width: 100, height: 25, isCircular: false),
+            verticalSpace(70),
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: ShimmerItem(width: 100, height: 25, isCircular: false),
+            ),
+            verticalSpace(35),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 50.0),
+              child: ShimmerItem(
+                  width: double.infinity, height: 10, isCircular: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/recipe/ui/widgets/shimmer_item.dart
+++ b/lib/features/recipe/ui/widgets/shimmer_item.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class ShimmerItem extends StatelessWidget {
+  const ShimmerItem(
+      {super.key,
+      required this.width,
+      required this.height,
+      required this.isCircular});
+
+  final double width;
+  final double height;
+  final bool isCircular;
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      period: const Duration(milliseconds: 500),
+      baseColor: Colors.grey,
+      highlightColor: Colors.white,
+      child: Container(
+        height: height,
+        width: width,
+        decoration: BoxDecoration(
+          shape: isCircular ? BoxShape.circle : BoxShape.rectangle,
+          color: Colors.grey,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/see_more/ui/widgets/filtered_recipe_item.dart
+++ b/lib/features/see_more/ui/widgets/filtered_recipe_item.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:food_recipes_app/core/helpers/extensions.dart';
+import 'package:food_recipes_app/core/models/recipe_item_model.dart';
+import 'package:food_recipes_app/core/routing/app_routes.dart';
 import 'package:food_recipes_app/core/theming/app_colors.dart';
 import 'package:food_recipes_app/core/theming/app_text_styles.dart';
 import 'package:food_recipes_app/features/see_more/data/models/filtered_recipe_item_model.dart';
+import 'package:food_recipes_app/features/see_more/logic/cubit/see_more_cubit.dart';
 
 class FilteredRecipeItem extends StatelessWidget {
   const FilteredRecipeItem({super.key, required this.recipe});
@@ -11,25 +16,30 @@ class FilteredRecipeItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      alignment: Alignment.topCenter,
-      children: [
-        Padding(
-          padding: EdgeInsets.only(top: 25.h),
-          child: Container(
-            width: 160.w,
-            padding: EdgeInsets.symmetric(horizontal: 10.w, vertical: 20.h),
-            decoration: _getDecoration(),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                _buildItemTitle(),
-              ],
+    return GestureDetector(
+      onTap: () {
+        _onRecipeTap(context);
+      },
+      child: Stack(
+        alignment: Alignment.topCenter,
+        children: [
+          Padding(
+            padding: EdgeInsets.only(top: 25.h),
+            child: Container(
+              width: 160.w,
+              padding: EdgeInsets.symmetric(horizontal: 10.w, vertical: 20.h),
+              decoration: _getDecoration(),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  _buildItemTitle(),
+                ],
+              ),
             ),
           ),
-        ),
-        _buildItemImage(),
-      ],
+          _buildItemImage(),
+        ],
+      ),
     );
   }
 
@@ -66,5 +76,12 @@ class FilteredRecipeItem extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  void _onRecipeTap(BuildContext context) {
+    final String categoryName = context.read<SeeMoreCubit>().categoryName;
+    final recipeFromId =
+        RecipeItemModel.fromId(id: recipe.id, section: categoryName);
+    context.pushNamed(AppRoutes.recipeDetails, arguments: recipeFromId);
   }
 }


### PR DESCRIPTION
- Created the `RecipeRepo` `RecipeCubit` and `RecipeState` classes to handle the states of the recipe details screen.
- Made the `FilteredRecipeItem` tappable in `SeeMoreScreen` to navigate to `RecipeScreen`.
- Added `RecipeItemModel.fromId` constructor to hold the `recipe id` and `recipe section` to pass them to recipe details screen.
- Created searching by id logic in `RecipeRepo` and `RecipeCubit` to display the recipes details for the recipes came from the `SeeMoreScreen`.
- Added search endpoint to `api_constant` file.
- Wrapped the `RecipeScreen` with bloc provider in `app_router` file to provide its cubit.
- Refactor the `RecipeScreen` widget to fit the new logic.
- Created the `RecipeScreenShimmer` `RecipeScreenBody` and `RecipeScreenError` widgets.